### PR TITLE
default values to dependencies fields

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,8 +122,8 @@ function startBowerWatch(context: vscode.ExtensionContext) {
 }
 
 function installPackages(packageJson: Package, callback: any) {
-    typingsService.install(packageJson.dependencies, false, writeOutput, (counta) => {
-        typingsService.install(packageJson.devDependencies, true, writeOutput, (countb) => callback(counta + countb));
+    typingsService.install(packageJson.dependencies || {}, false, writeOutput, (counta) => {
+        typingsService.install(packageJson.devDependencies || {}, true, writeOutput, (countb) => callback(counta + countb));
     });
 
 }


### PR DESCRIPTION
Hi, been using this extension for a while now and I notice it wasn't working on some cases, so used the devtools to do a bit of debugging and it seems like this problem occurs when you have only devDependencies field on your package.json.
